### PR TITLE
Fix failing azure pipelines checks

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -5,9 +5,9 @@ jobs:
 
     steps:
       - task: UsePythonVersion@0
-        displayName: Use python 3.8.3
+        displayName: Use python 3.8.5
         inputs:
-          versionSpec: "3.8.3"
+          versionSpec: "3.8.5"
 
       - script: |
           python -m pip install --upgrade pip setuptools wheel pipenv


### PR DESCRIPTION
Azure pipelines checks were failing bacause of an old python version (`3.8.3`) being used.
This bumps python version in azure pipelines to 3.8.5